### PR TITLE
Add CreateBlog command and refactor GetBlogById query

### DIFF
--- a/CleanArchitectureDemo.Application/Blogs/Commands/CreateBlog/CreateBlogCommand.cs
+++ b/CleanArchitectureDemo.Application/Blogs/Commands/CreateBlog/CreateBlogCommand.cs
@@ -1,0 +1,7 @@
+﻿using CleanArchitectureDemo.Application.Blogs.Queries.GetBlogs;
+using MediatR;
+
+namespace CleanArchitectureDemo.Application.Blogs.Commands.CreateBlog
+{
+	public record CreateBlogCommand(string Title, string Content, string Author) : IRequest<BlogVM>;
+}

--- a/CleanArchitectureDemo.Application/Blogs/Commands/CreateBlog/CreateBlogCommandHandler.cs
+++ b/CleanArchitectureDemo.Application/Blogs/Commands/CreateBlog/CreateBlogCommandHandler.cs
@@ -1,0 +1,29 @@
+﻿using AutoMapper;
+using CleanArchitectureDemo.Application.Blogs.Queries.GetBlogs;
+using CleanArchitectureDemo.Domain.Entity;
+using CleanArchitectureDemo.Domain.Repository;
+using MediatR;
+
+namespace CleanArchitectureDemo.Application.Blogs.Commands.CreateBlog
+{
+	public class CreateBlogCommandHandler : IRequestHandler<CreateBlogCommand, BlogVM>
+	{
+		private readonly IBlogRepository _repository;
+		private readonly IMapper _mapper;
+
+		public CreateBlogCommandHandler(IBlogRepository repository, IMapper mapper)
+		{
+			this._repository = repository;
+			this._mapper = mapper;
+		}
+
+		public async Task<BlogVM> Handle(CreateBlogCommand request, CancellationToken cancellationToken)
+		{
+			Blog blogEntity = new() { Author = request.Author, Content = request.Content, Title = request.Title };
+
+			var result = await _repository.CreateAsync(blogEntity);
+
+			return _mapper.Map<BlogVM>(result);
+		}
+	}
+}

--- a/CleanArchitectureDemo.Application/Blogs/Queries/GetBlogById/GetBlogByIdQuery.cs
+++ b/CleanArchitectureDemo.Application/Blogs/Queries/GetBlogById/GetBlogByIdQuery.cs
@@ -3,8 +3,5 @@ using MediatR;
 
 namespace CleanArchitectureDemo.Application.Blogs.Queries.GetBlogById
 {
-	public class GetBlogByIdQuery : IRequest<BlogVM>
-	{
-		public int BlogId { get; set; }
-	}
+	public record GetBlogByIdQuery(int BlogId) : IRequest<BlogVM>;
 }

--- a/CleanArchitectureDemo.Application/CleanArchitectureDemo.Application.csproj
+++ b/CleanArchitectureDemo.Application/CleanArchitectureDemo.Application.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Blogs\Commands\CreateBlog\" />
     <Folder Include="Blogs\Commands\DeleteBlog\" />
     <Folder Include="Blogs\Commands\UpdateBlog\" />
     <Folder Include="Common\Behaviours\" />


### PR DESCRIPTION
Add CreateBlog command and refactor GetBlogById query

- Introduced `CreateBlogCommand` record with parameters for Title, Content, and Author.
- Implemented `CreateBlogCommandHandler` to handle command execution and mapping to `BlogVM`.
- Refactored `GetBlogByIdQuery` to use a record instead of a class.
- Removed the `Blogs\Commands\CreateBlog\` folder from the project structure.