### PR TITLE
Add delete blog command and handler implementation

### DIFF
--- a/CleanArchitectureDemo.Application/Blogs/Commands/DeleteBlog/DeleteBlogCommand.cs
+++ b/CleanArchitectureDemo.Application/Blogs/Commands/DeleteBlog/DeleteBlogCommand.cs
@@ -1,0 +1,6 @@
+﻿using MediatR;
+
+namespace CleanArchitectureDemo.Application.Blogs.Commands.DeleteBlog
+{
+	public record DeleteBlogCommand(int Id) : IRequest<int>;
+}

--- a/CleanArchitectureDemo.Application/Blogs/Commands/DeleteBlog/DeleteBlogCommandHandler.cs
+++ b/CleanArchitectureDemo.Application/Blogs/Commands/DeleteBlog/DeleteBlogCommandHandler.cs
@@ -1,0 +1,23 @@
+﻿using AutoMapper;
+using CleanArchitectureDemo.Domain.Repository;
+using MediatR;
+
+namespace CleanArchitectureDemo.Application.Blogs.Commands.DeleteBlog
+{
+	public class DeleteBlogCommandHandler : IRequestHandler<DeleteBlogCommand, int>
+	{
+		private readonly IBlogRepository _repository;
+		private readonly IMapper _mapper;
+
+		public DeleteBlogCommandHandler(IBlogRepository repository, IMapper mapper)
+		{
+			this._repository = repository;
+			this._mapper = mapper;
+		}
+
+		public async Task<int> Handle(DeleteBlogCommand request, CancellationToken cancellationToken)
+		{
+			return await _repository.DeleteAsync(request.Id);
+		}
+	}
+}

--- a/CleanArchitectureDemo.Application/CleanArchitectureDemo.Application.csproj
+++ b/CleanArchitectureDemo.Application/CleanArchitectureDemo.Application.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Blogs\Commands\DeleteBlog\" />
     <Folder Include="Common\Behaviours\" />
     <Folder Include="Common\Exceptions\" />
   </ItemGroup>

--- a/CleanArchitectureDemo.Domain/Repository/IBlogRepository.cs
+++ b/CleanArchitectureDemo.Domain/Repository/IBlogRepository.cs
@@ -8,6 +8,6 @@ namespace CleanArchitectureDemo.Domain.Repository
 		Task<Blog?> GetByIdAsync(int id);
 		Task<Blog> CreateAsync(Blog blog);
 		Task<int> UpdateAsync(int id, Blog blog);
-		Task<bool> DeleteAsync(int id);
+		Task<int> DeleteAsync(int id);
 	}
 }


### PR DESCRIPTION
Add delete blog command and handler implementation

- Introduced `DeleteBlogCommand` to handle blog deletions.
- Created `DeleteBlogCommandHandler` with dependencies on `IBlogRepository` and `IMapper`.
- Updated `IBlogRepository.DeleteAsync` to return `Task<int>` instead of `Task<bool>`.
- Removed folder entry for `DeleteBlog` commands in the project structure.