### PR TITLE
Add Entity Framework Core support for Blog management

### DIFF
--- a/CleanArchitectureDemo.Infrastructure/CleanArchitectureDemo.Infrastructure.csproj
+++ b/CleanArchitectureDemo.Infrastructure/CleanArchitectureDemo.Infrastructure.csproj
@@ -7,11 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Data\" />
-    <Folder Include="Repository\" />
-  </ItemGroup>
-
-  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.3" />
   </ItemGroup>
 

--- a/CleanArchitectureDemo.Infrastructure/ConfigureServices.cs
+++ b/CleanArchitectureDemo.Infrastructure/ConfigureServices.cs
@@ -1,13 +1,25 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using CleanArchitectureDemo.Domain.Repository;
+using CleanArchitectureDemo.Infrastructure.Data;
+using CleanArchitectureDemo.Infrastructure.Repository;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace CleanArchitectureDemo.Infrastructure
 {
 	public static class ConfigureServices
 	{
+		private const string connectionName = "BlogDbConnection";
+
 		public static IServiceCollection AddInfrastructureServices(this IServiceCollection services, IConfiguration configuration)
 		{
+			services.AddDbContext<BlogDbContext>(options =>
+			{
+				options.UseSqlite(configuration.GetConnectionString(connectionName) ??
+					throw new InvalidOperationException($"Connection string {connectionName} not found"));
+			});
 
+			services.AddTransient<IBlogRepository, BlogRepository>();
 
 			return services;
 		}

--- a/CleanArchitectureDemo.Infrastructure/Data/BlogDbContext.cs
+++ b/CleanArchitectureDemo.Infrastructure/Data/BlogDbContext.cs
@@ -1,0 +1,14 @@
+﻿using CleanArchitectureDemo.Domain.Entity;
+using Microsoft.EntityFrameworkCore;
+
+namespace CleanArchitectureDemo.Infrastructure.Data
+{
+	public class BlogDbContext : DbContext
+	{
+		public BlogDbContext(DbContextOptions<BlogDbContext> dbContextOptions) : base(dbContextOptions)
+		{
+		}
+
+		public DbSet<Blog> Blogs { get; set; }
+	}
+}

--- a/CleanArchitectureDemo.Infrastructure/Repository/BlogRepository.cs
+++ b/CleanArchitectureDemo.Infrastructure/Repository/BlogRepository.cs
@@ -1,0 +1,48 @@
+﻿using CleanArchitectureDemo.Domain.Entity;
+using CleanArchitectureDemo.Domain.Repository;
+using CleanArchitectureDemo.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace CleanArchitectureDemo.Infrastructure.Repository
+{
+	public class BlogRepository : IBlogRepository
+	{
+		private readonly BlogDbContext _blogDbContext;
+
+		public BlogRepository(BlogDbContext blogDbContext)
+		{
+			this._blogDbContext = blogDbContext;
+		}
+
+		public async Task<Blog> CreateAsync(Blog blog)
+		{
+			await _blogDbContext.Blogs.AddAsync(blog);
+			await _blogDbContext.SaveChangesAsync();
+
+			return blog;
+		}
+
+		public async Task<int> DeleteAsync(int id)
+		{
+			return await _blogDbContext.Blogs.Where(b => b.Id == id).ExecuteDeleteAsync();
+		}
+
+		public async Task<List<Blog>> GetAllAsync()
+		{
+			return await _blogDbContext.Blogs.AsNoTracking().ToListAsync();
+		}
+
+		public Task<Blog?> GetByIdAsync(int id)
+		{
+			return _blogDbContext.Blogs.AsNoTracking().FirstOrDefaultAsync(b => b.Id == id);
+		}
+
+		public async Task<int> UpdateAsync(int id, Blog blog)
+		{
+			return await _blogDbContext.Blogs.Where(b => b.Id == id).ExecuteUpdateAsync(setters => setters
+				.SetProperty(b => b.Title, blog.Title)
+				.SetProperty(b => b.Content, blog.Content)
+				.SetProperty(b => b.Author, blog.Author));
+		}
+	}
+}


### PR DESCRIPTION
Add Entity Framework Core support for Blog management

Updated project to include Entity Framework Core and SQLite packages.
Implemented `AddInfrastructureServices` for DbContext configuration and
registered `IBlogRepository` with its implementation. Created
`BlogDbContext` and `BlogRepository` for managing Blog entities
asynchronously.